### PR TITLE
Activation updates for linux-64.

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,4 @@
-CHOST:
-  - x86_64-conda-linux-gnu  # [linux64]
+CHOST:                                              # [linux64]
+  - x86_64-conda-linux-gnu                          # [linux64]
+FINAL_PYTHON_SYSCONFIGDATA_NAME:                    # [linux64]
+  - _sysconfigdata_x86_64_conda_linux_gnu           # [linux64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+CHOST:
+  - x86_64-conda-linux-gnu  # [linux64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,8 @@ source:
     folder: dpcpp_impl_{{ target_platform }}
   - url: https://anaconda.org/intel/dpcpp_{{ target_platform }}/{{ version }}/download/{{ target_platform }}/dpcpp_{{ target_platform }}-{{ version }}-intel_{{ intel_build_number }}.tar.bz2
     folder: dpcpp_{{ target_platform }}
+    patches:
+      - patches/0001-dpcpp-activation.patch
   {% endif %}
   {% if linux64 %}
   - url: https://anaconda.org/intel/oneccl-devel/{{ version }}/download/{{ target_platform }}/oneccl-devel-{{ version }}-intel_{{ oneccl_build_number }}.tar.bz2
@@ -49,6 +51,11 @@ build:
     # Note: any output that specifies a 'build' section will need to include this
     # because it gets overwritten? what about binary_relocation / detect_binary_files_with_prefix?
     - '*'
+
+requirements:
+  build:
+    - patch     # [unix]
+    - m2-patch  # [win]
 
 outputs:
   - name: intel-cmplr-lic-rt
@@ -201,10 +208,17 @@ outputs:
         # 2. Pin to year for now, similar to MKL.
         strong:
           - {{ pin_subpackage("dpcpp-cpp-rt", max_pin="x") }}
+          - libgcc-ng >={{ c_compiler_version }}
+          - libstdcxx-ng >={{ cxx_compiler_version }}
     requirements:
       run:
         - {{ pin_subpackage('dpcpp-cpp-rt', exact=True) }}
-
+        # compiler's need a sysroot "/"
+        - sysroot_{{ target_platform }}   # [linux]
+        # targets --rtlib=libgcc because compiler-rt builtins is not provided.
+        - gcc_impl_{{ target_platform }}  # [linux]
+        # these binaries target -stdlib=libstdc++
+        - gxx_impl_{{ target_platform }}  # [linux]
     about:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
       doc_url: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html
@@ -220,25 +234,31 @@ outputs:
         This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
     test:
       commands:
-        - ls -A1 ${PREFIX}/bin/*         # [unix]
-        - ls -A1 ${PREFIX}/include/*     # [unix]
-        - ls -A1 ${PREFIX}/lib/*         # [unix]
+        - ls -A1 ${PREFIX}/bin/*         # [linux]
+        - ls -A1 ${PREFIX}/include/*     # [linux]
+        - ls -A1 ${PREFIX}/lib/*         # [linux]
         - dir %PREFIX%\Library\bin\*  # [win]
         - dir %PREFIX%\Library\lib\*  # [win]
 
   - name: dpcpp_{{ target_platform }}
-    script: repack.sh   # [unix]
-    script: repack.bat  # [win]
+    script: update-activate-and-repack.sh   # [unix]
+    script: repack.bat                      # [win]
     build:
       skip: True  # [not (linux64 or win64)]
       missing_dso_whitelist:
         - '*'
+      # these are duplicated from the dpcpp_impl* in order to ensure they are followed.
       run_exports:
         # 1. strong so if gets added if this package is in the build requirement section.
         # 2. Pin to year for now, similar to MKL.
         strong:
           - {{ pin_subpackage("dpcpp-cpp-rt", max_pin="x") }}
+          - libgcc-ng >={{ c_compiler_version }}
+          - libstdcxx-ng >={{ cxx_compiler_version }}
     requirements:   # [linux64 or win64]
+      # for us to be able to use clang/icx -dumpmachine
+      build:          # [linux64 or win64]
+        - dpcpp_impl_{{ target_platform }}  # [linux64 or win64]
       run:          # [linux64 or win64]
         - {{ pin_subpackage('dpcpp_impl_linux-64', exact=True) }} # [linux64]
         - {{ pin_subpackage('dpcpp_impl_win-64', exact=True) }}   # [win64]
@@ -257,9 +277,9 @@ outputs:
         This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
     test:
       commands:
-        - ls -A1 ${PREFIX}/bin/*         # [unix]
-        - ls -A1 ${PREFIX}/include/*     # [unix]
-        - ls -A1 ${PREFIX}/lib/*         # [unix]
+        - ls -A1 ${PREFIX}/bin/*         # [linux]
+        - ls -A1 ${PREFIX}/include/*     # [linux]
+        - ls -A1 ${PREFIX}/lib/*         # [linux]
         - dir %PREFIX%\Library\bin\*  # [win]
         - dir %PREFIX%\Library\lib\*  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,8 @@ source:
 
 build:
   number: {{ intel_build_number|int + dst_build_number|int }}
-  skip: True                                  # [not (linux64 or win or osx)]
+  # skip if target is not x86_64, which is only supported on linux, osx, and win.
+  skip: True                                  # [not x86_64 or not (linux or osx or win)]
   missing_dso_whitelist:
     # these are binary repackages after all.
     # Note: any output that specifies a 'build' section will need to include this

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,8 +43,6 @@ source:
 
 build:
   number: {{ intel_build_number|int + dst_build_number|int }}
-  binary_relocation: false
-  detect_binary_files_with_prefix: false
   skip: True                                  # [not (linux64 or win or osx)]
   missing_dso_whitelist:
     # these are binary repackages after all.
@@ -248,7 +246,7 @@ outputs:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
       doc_url: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html
       dev_url: https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top.html
-      summary: Implementation for Intel® oneAPI DPC++/C++ Compiler
+      summary: Activation for Intel® oneAPI DPC++/C++ Compiler
       license: Intel End User License Agreement for Developer Tools
       license_family: Proprietary
       license_file:                                                   # [linux64 or win64]
@@ -268,7 +266,6 @@ outputs:
   - name: oneccl-devel
     script: repack.sh   # [unix]
     build:
-      number: {{ oneccl_build_number|int + dst_build_number|int }}
       skip: True  # [not linux64]
       missing_dso_whitelist:
         - '*'

--- a/recipe/patches/0001-dpcpp-activation.patch
+++ b/recipe/patches/0001-dpcpp-activation.patch
@@ -1,5 +1,5 @@
 diff --git a/etc/conda/activate.d/activate-dpcpp.sh b/etc/conda/activate.d/activate-dpcpp.sh
-index c21165a..98908fb 100755
+index c21165a..cbbc756 100755
 --- a/etc/conda/activate.d/activate-dpcpp.sh
 +++ b/etc/conda/activate.d/activate-dpcpp.sh
 @@ -83,12 +83,40 @@ function _tc_activation() {
@@ -43,7 +43,7 @@ index c21165a..98908fb 100755
    CPATH_USED="${CONDA_PREFIX}/include:${CONDA_PREFIX}"
    LIBRARY_PATH_USED="${CONDA_PREFIX}/compiler/lib:${LIBRARY_PATH}"
    LD_LIBRARY_PATH_USED="${CONDA_PREFIX}/compiler/lib/intel64_lin:${CONDA_PREFIX}/compiler/lib:${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"
-@@ -103,10 +131,29 @@ fi
+@@ -103,10 +131,30 @@ fi
  
  _tc_activation \
    activate @CHOST@- "HOST,@CHOST@" "BUILD,@CBUILD@" \
@@ -61,6 +61,7 @@ index c21165a..98908fb 100755
 +  "LDFLAGS,${LDFLAGS:-${LDFLAGS_USED}}" \
 +  "LDFLAGS_LD,${LDFLAGS_LD:-${LDFLAGS_LD_USED}}" \
 +  "CONDA_BUILD_SYSROOT,${CONDA_BUILD_SYSROOT_USED:-}" \
++  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME:-@_PYTHON_SYSCONFIGDATA_NAME@}" \
 +  "CMAKE_ARGS,${_CMAKE_ARGS:-}" \
 +  "CONDA_BUILD_CROSS_COMPILATION,@CONDA_BUILD_CROSS_COMPILATION@" \
 +  "CMAKE_PREFIX_PATH,${CMAKE_PREFIX_PATH_USED}" \
@@ -74,7 +75,7 @@ index c21165a..98908fb 100755
    echo "ERROR: $(_get_sourced_filename) failed, see above for details"
  else
 diff --git a/etc/conda/deactivate.d/deactivate-dpcpp.sh b/etc/conda/deactivate.d/deactivate-dpcpp.sh
-index 6975b03..bd1b858 100755
+index 6975b03..a4ff33f 100755
 --- a/etc/conda/deactivate.d/deactivate-dpcpp.sh
 +++ b/etc/conda/deactivate.d/deactivate-dpcpp.sh
 @@ -83,11 +83,32 @@ function _tc_activation() {
@@ -110,7 +111,7 @@ index 6975b03..bd1b858 100755
    CPATH_USED="${CONDA_PREFIX}/include:${CONDA_PREFIX}"
    LIBRARY_PATH_USED="${CONDA_PREFIX}/compiler/lib:${LIBRARY_PATH}"
    LD_LIBRARY_PATH_USED="${CONDA_PREFIX}/compiler/lib/intel64_lin:${CONDA_PREFIX}/compiler/lib:${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"
-@@ -102,6 +123,23 @@ fi
+@@ -102,6 +123,24 @@ fi
  
  _tc_activation \
    deactivate @CHOST@- "HOST,@CHOST@" "BUILD,@CBUILD@" \
@@ -128,6 +129,7 @@ index 6975b03..bd1b858 100755
 +  "LDFLAGS,${LDFLAGS:-${LDFLAGS_USED}}" \
 +  "LDFLAGS_LD,${LDFLAGS_LD:-${LDFLAGS_LD_USED}}" \
 +  "CONDA_BUILD_SYSROOT,${CONDA_BUILD_SYSROOT_USED:-}" \
++  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME:-@_PYTHON_SYSCONFIGDATA_NAME@}" \
 +  "CMAKE_ARGS,${_CMAKE_ARGS:-}" \
 +  "CONDA_BUILD_CROSS_COMPILATION,@CONDA_BUILD_CROSS_COMPILATION@" \
 +  "CMAKE_PREFIX_PATH,${CMAKE_PREFIX_PATH_USED}" \

--- a/recipe/patches/0001-dpcpp-activation.patch
+++ b/recipe/patches/0001-dpcpp-activation.patch
@@ -1,0 +1,136 @@
+diff --git a/etc/conda/activate.d/activate-dpcpp.sh b/etc/conda/activate.d/activate-dpcpp.sh
+index c21165a..98908fb 100755
+--- a/etc/conda/activate.d/activate-dpcpp.sh
++++ b/etc/conda/activate.d/activate-dpcpp.sh
+@@ -83,12 +83,40 @@ function _tc_activation() {
+   return 0
+ }
+ 
++CONDA_BUILD_SYSROOT_USED="${CONDA_PREFIX}/@CHOST@/sysroot"
++
++_CMAKE_ARGS="-DCMAKE_AR=${CONDA_PREFIX}/bin/@CHOST@-llvm-ar -DCMAKE_CXX_COMPILER_AR=${CONDA_PREFIX}/bin/@CHOST@-llvm-ar -DCMAKE_C_COMPILER_AR=${CONDA_PREFIX}/bin/@CHOST@-llvm-ar"
++_CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_RANLIB=${CONDA_PREFIX}/bin/@CHOST@-llvm-ranlib -DCMAKE_CXX_COMPILER_RANLIB=${CONDA_PREFIX}/bin/@CHOST@-llvm-ranlib -DCMAKE_C_COMPILER_RANLIB=${CONDA_PREFIX}/bin/@CHOST@-llvm-ranlib"
++_CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_LINKER=${CONDA_PREFIX}/bin/@CHOST@-ld.lld"
+ 
+ if [ "${CONDA_BUILD:-0}" = "1" ]; then
++  # add some more CMAKE stuff first.
++  _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY"
++  _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_FIND_ROOT_PATH=${PREFIX};${BUILD_PREFIX}/@CHOST@/sysroot"
++  _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=lib"
++
++  CFLAGS_USED="@CFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  DEBUG_CFLAGS_USED="@CFLAGS@ @DEBUG_CFLAGS@  --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  CPPFLAGS_USED="@CPPFLAGS@ -isystem ${PREFIX}/include"
++  DEBUG_CPPFLAGS_USED="@DEBUG_CPPFLAGS@ -isystem ${PREFIX}/include"
++  CXXFLAGS_USED="@CXXFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  DEBUG_CXXFLAGS_USED="@CXXFLAGS@ @DEBUG_CXXFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  LDFLAGS_USED="@LDFLAGS@ --target=@CHOST@ -Wl,-rpath,${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib -Wl,-rpath,${BUILD_PREFIX}/lib -Wl,-rpath-link,${BUILD_PREFIX}/lib -L${BUILD_PREFIX}/lib"
++  LDFLAGS_LD_USED="@LDFLAGS_LD@ --target=@CHOST@ -rpath ${PREFIX}/lib -rpath-link ${PREFIX}/lib -L${PREFIX}/lib -rpath ${BUILD_PREFIX}/lib -rpath-link ${BUILD_PREFIX}/lib -L${BUILD_PREFIX}/lib"
++  CMAKE_PREFIX_PATH_USED="${PREFIX}:${CONDA_PREFIX}/@CHOST@/sysroot/usr"
+   CPATH_USED="${PREFIX}/include:${CONDA_PREFIX}"
+   LIBRARY_PATH_USED="${PREFIX}/compiler/lib:${LIBRARY_PATH}"
+   LD_LIBRARY_PATH_USED="${PREFIX}/compiler/lib/intel64_lin:${PREFIX}/compiler/lib:${PREFIX}/lib:${LD_LIBRARY_PATH}"
+ else
++  CFLAGS_USED="@CFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  DEBUG_CFLAGS_USED="@DEBUG_CFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  CPPFLAGS_USED="@CPPFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  DEBUG_CPPFLAGS_USED="@DEBUG_CPPFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  CXXFLAGS_USED="@CXXFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  DEBUG_CXXFLAGS_USED="@DEBUG_CXXFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  LDFLAGS_USED="@LDFLAGS@ -Wl,-rpath,${CONDA_PREFIX}/lib -Wl,-rpath-link,${CONDA_PREFIX}/lib -L${CONDA_PREFIX}/lib"
++  LDFLAGS_LD_USED="@LDFLAGS_LD@ -rpath ${CONDA_PREFIX}/lib -rpath-link ${CONDA_PREFIX}/lib -L${CONDA_PREFIX}/lib"
++  CMAKE_PREFIX_PATH_USED="${CONDA_PREFIX}:${CONDA_PREFIX}/@CHOST@/sysroot/usr"
+   CPATH_USED="${CONDA_PREFIX}/include:${CONDA_PREFIX}"
+   LIBRARY_PATH_USED="${CONDA_PREFIX}/compiler/lib:${LIBRARY_PATH}"
+   LD_LIBRARY_PATH_USED="${CONDA_PREFIX}/compiler/lib/intel64_lin:${CONDA_PREFIX}/compiler/lib:${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"
+@@ -103,10 +131,29 @@ fi
+ 
+ _tc_activation \
+   activate @CHOST@- "HOST,@CHOST@" "BUILD,@CBUILD@" \
++  "CC,${CC:-@CHOST@-icx}" \
++  "CXX,${CXX:-@CHOST@-icpx}" \
++  "LD,${LD:-@CHOST@-ld.lld}" \
++  "AR,${AR:-@CHOST@-llvm-ar}" \
++  "RANLIB,${RANLIB:-@CHOST@-llvm-ranlib}" \
++  "CFLAGS,${CFLAGS:-${CFLAGS_USED}}" \
++  "DEBUG_CFLAGS,${DEBUG_CFLAGS:-${DEBUG_CFLAGS_USED}}" \
++  "CPPFLAGS,${CPPFLAGS:-${CPPFLAGS_USED}}" \
++  "DEBUG_CPPFLAGS,${DEBUG_CPPFLAGS:-${DEBUG_CPPFLAGS_USED}}" \
++  "CXXFLAGS,${CXXFLAGS:-${CXXFLAGS_USED}}" \
++  "DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-${DEBUG_CXXFLAGS_USED}}" \
++  "LDFLAGS,${LDFLAGS:-${LDFLAGS_USED}}" \
++  "LDFLAGS_LD,${LDFLAGS_LD:-${LDFLAGS_LD_USED}}" \
++  "CONDA_BUILD_SYSROOT,${CONDA_BUILD_SYSROOT_USED:-}" \
++  "CMAKE_ARGS,${_CMAKE_ARGS:-}" \
++  "CONDA_BUILD_CROSS_COMPILATION,@CONDA_BUILD_CROSS_COMPILATION@" \
++  "CMAKE_PREFIX_PATH,${CMAKE_PREFIX_PATH_USED}" \
+   "CPATH,${CPATH:-${CPATH_USED}}" \
+   "LIBRARY_PATH,${LIBRARY_PATH:-${LIBRARY_PATH_USED}}" \
+   "LD_LIBRARY_PATH,${LD_LIBRARY_PATH:-${LD_LIBRARY_PATH_USED}}"
+ 
++unset _CMAKE_ARGS
++
+ if [ $? -ne 0 ]; then
+   echo "ERROR: $(_get_sourced_filename) failed, see above for details"
+ else
+diff --git a/etc/conda/deactivate.d/deactivate-dpcpp.sh b/etc/conda/deactivate.d/deactivate-dpcpp.sh
+index 6975b03..bd1b858 100755
+--- a/etc/conda/deactivate.d/deactivate-dpcpp.sh
++++ b/etc/conda/deactivate.d/deactivate-dpcpp.sh
+@@ -83,11 +83,32 @@ function _tc_activation() {
+   return 0
+ }
+ 
++CONDA_BUILD_SYSROOT_USED="${CONDA_PREFIX}/@CHOST@/sysroot"
++
+ if [ "${CONDA_BUILD:-0}" = "1" ]; then
++
++  CFLAGS_USED="@CFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  DEBUG_CFLAGS_USED="@CFLAGS@ @DEBUG_CFLAGS@  --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  CPPFLAGS_USED="@CPPFLAGS@ -isystem ${PREFIX}/include"
++  DEBUG_CPPFLAGS_USED="@DEBUG_CPPFLAGS@ -isystem ${PREFIX}/include"
++  CXXFLAGS_USED="@CXXFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  DEBUG_CXXFLAGS_USED="@CXXFLAGS@ @DEBUG_CXXFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  LDFLAGS_USED="@LDFLAGS@ --target=@CHOST@ -Wl,-rpath,${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib -Wl,-rpath,${BUILD_PREFIX}/lib -Wl,-rpath-link,${BUILD_PREFIX}/lib -L${BUILD_PREFIX}/lib"
++  LDFLAGS_LD_USED="@LDFLAGS_LD@ --target=@CHOST@ -rpath ${PREFIX}/lib -rpath-link ${PREFIX}/lib -L${PREFIX}/lib -rpath ${BUILD_PREFIX}/lib -rpath-link ${BUILD_PREFIX}/lib -L${BUILD_PREFIX}/lib"
++  CMAKE_PREFIX_PATH_USED="${PREFIX}:${CONDA_PREFIX}/@CHOST@/sysroot/usr"
+   CPATH_USED="${PREFIX}/include:${CONDA_PREFIX}"
+   LIBRARY_PATH_USED="${PREFIX}/compiler/lib:${LIBRARY_PATH}"
+   LD_LIBRARY_PATH_USED="${PREFIX}/compiler/lib/intel64_lin:${PREFIX}/compiler/lib:${PREFIX}/lib:${LD_LIBRARY_PATH}"
+ else
++  CFLAGS_USED="@CFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  DEBUG_CFLAGS_USED="@DEBUG_CFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  CPPFLAGS_USED="@CPPFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  DEBUG_CPPFLAGS_USED="@DEBUG_CPPFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  CXXFLAGS_USED="@CXXFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  DEBUG_CXXFLAGS_USED="@DEBUG_CXXFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  LDFLAGS_USED="@LDFLAGS@ -Wl,-rpath,${CONDA_PREFIX}/lib -Wl,-rpath-link,${CONDA_PREFIX}/lib -L${CONDA_PREFIX}/lib"
++  LDFLAGS_LD_USED="@LDFLAGS_LD@ -rpath ${CONDA_PREFIX}/lib -rpath-link ${CONDA_PREFIX}/lib -L${CONDA_PREFIX}/lib"
++  CMAKE_PREFIX_PATH_USED="${CONDA_PREFIX}:${CONDA_PREFIX}/@CHOST@/sysroot/usr"
+   CPATH_USED="${CONDA_PREFIX}/include:${CONDA_PREFIX}"
+   LIBRARY_PATH_USED="${CONDA_PREFIX}/compiler/lib:${LIBRARY_PATH}"
+   LD_LIBRARY_PATH_USED="${CONDA_PREFIX}/compiler/lib/intel64_lin:${CONDA_PREFIX}/compiler/lib:${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"
+@@ -102,6 +123,23 @@ fi
+ 
+ _tc_activation \
+   deactivate @CHOST@- "HOST,@CHOST@" "BUILD,@CBUILD@" \
++  "CC,${CC:-@CHOST@-icx}" \
++  "CXX,${CXX:-@CHOST@-icpx}" \
++  "LD,${LD:-@CHOST@-ld.lld}" \
++  "AR,${AR:-@CHOST@-llvm-ar}" \
++  "RANLIB,${RANLIB:-@CHOST@-llvm-ranlib}" \
++  "CFLAGS,${CFLAGS:-${CFLAGS_USED}}" \
++  "DEBUG_CFLAGS,${DEBUG_CFLAGS:-${DEBUG_CFLAGS_USED}}" \
++  "CPPFLAGS,${CPPFLAGS:-${CPPFLAGS_USED}}" \
++  "DEBUG_CPPFLAGS,${DEBUG_CPPFLAGS:-${DEBUG_CPPFLAGS_USED}}" \
++  "CXXFLAGS,${CXXFLAGS:-${CXXFLAGS_USED}}" \
++  "DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-${DEBUG_CXXFLAGS_USED}}" \
++  "LDFLAGS,${LDFLAGS:-${LDFLAGS_USED}}" \
++  "LDFLAGS_LD,${LDFLAGS_LD:-${LDFLAGS_LD_USED}}" \
++  "CONDA_BUILD_SYSROOT,${CONDA_BUILD_SYSROOT_USED:-}" \
++  "CMAKE_ARGS,${_CMAKE_ARGS:-}" \
++  "CONDA_BUILD_CROSS_COMPILATION,@CONDA_BUILD_CROSS_COMPILATION@" \
++  "CMAKE_PREFIX_PATH,${CMAKE_PREFIX_PATH_USED}" \
+   "CPATH,${CPATH:-${CPATH_USED}}" \
+   "LIBRARY_PATH,${LIBRARY_PATH:-${LIBRARY_PATH_USED}}" \
+   "LD_LIBRARY_PATH,${LD_LIBRARY_PATH:-${LD_LIBRARY_PATH_USED}}"

--- a/recipe/repack.sh
+++ b/recipe/repack.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -eux
 
 # for subpackages, we have named our extracted locations according to the subpackage name
 #    That's what this $PKG_NAME is doing - picking the right subfolder to rsync
@@ -7,6 +7,15 @@ set -ex
 src="${SRC_DIR}/${PKG_NAME}"
 
 cp -rv "${src}"/* "${PREFIX}/"
+
+# special case to set up compilers with host prepended.
+if [[ ${PKG_NAME} =~ dpcpp_impl_.* ]]; then
+    pushd "${PREFIX}"/bin
+        for file in *; do
+            ln -sfv ${file} ${CHOST}-${file}
+        done
+    popd
+fi
 
 # replace old info folder with our new regenerated one
 rm -rf "${PREFIX}/info"

--- a/recipe/update-activate-and-repack.sh
+++ b/recipe/update-activate-and-repack.sh
@@ -7,14 +7,14 @@ src="${SRC_DIR}/${PKG_NAME}"
 CBUILD=$(${PREFIX}/bin/icx -dumpmachine | sed "s/unknown/conda/")
 CHOST=$(${PREFIX}/bin/icx -dumpmachine | sed "s/unknown/conda/")
 
-FINAL_CFLAGS="-march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe"
-FINAL_DEBUG_CFLAGS="-march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -ffunction-sections -pipe"
-FINAL_CPPFLAGS="-DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -fuse-ld=lld"
-FINAL_DEBUG_CPPFLAGS="-D_DEBUG -D_FORTIFY_SOURCE=2 -Og -fuse-ld=lld"
-FINAL_CXXFLAGS="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe"
-FINAL_DEBUG_CXXFLAGS="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -ffunction-sections -pipe"
-FINAL_LDFLAGS="-Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,--disable-new-dtags -Wl,--gc-sections -fuse-ld=lld"
-FINAL_LDFLAGS_LD="-O2 --sort-common --as-needed -z relro -z now --disable-new-dtags --gc-sections -fuse-ld=lld"
+FINAL_CFLAGS="-Wformat -Wformat-security -O3 -fp-model strict -fomit-frame-pointer -xSSE4.2 -axCORE-AVX2,COMMON-AVX512 -fPIC -fstack-protector-all -fno-plt -ftree-vectorize -ffunction-sections -pipe"
+FINAL_DEBUG_CFLAGS="-Wformat -Wformat-security -O0g -g -fp-model strict -fomit-frame-pointer -xSSE4.2 -axCORE-AVX2,COMMON-AVX512 -fPIC -fstack-protector-all -fno-plt -ftree-vectorize -ffunction-sections -pipe"
+FINAL_CPPFLAGS="-DNDEBUG -D_FORTIFY_SOURCE=2"
+FINAL_DEBUG_CPPFLAGS="-D_DEBUG -D_FORTIFY_SOURCE=2 -Og"
+FINAL_CXXFLAGS="-std=c++17 -Wformat -Wformat-security -O3 -fp-model strict -fomit-frame-pointer -xSSE4.2 -axCORE-AVX2,COMMON-AVX512 -fPIC -fstack-protector-all"
+FINAL_DEBUG_CXXFLAGS="-std=c++17 -Wformat -Wformat-security -O0g -g -fp-model strict -fomit-frame-pointer -xSSE4.2 -axCORE-AVX2,COMMON-AVX512 -fPIC -fstack-protector-all"
+FINAL_LDFLAGS="-Wl,-O3 -Wl,--sort-common -Wl,--as-needed -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--disable-new-dtags -Wl,--gc-sections -fuse-ld=lld"
+FINAL_LDFLAGS_LD="-O0g -g --sort-common --as-needed -z noexecstack -z relro -z now --disable-new-dtags --gc-sections -fuse-ld=lld"
 
 # if [[ "$target_platform" == "$ctng_target_platform" ]]; then
 #   export CONDA_BUILD_CROSS_COMPILATION=""

--- a/recipe/update-activate-and-repack.sh
+++ b/recipe/update-activate-and-repack.sh
@@ -37,6 +37,7 @@ find . -name "*activate*.sh" -exec sed -i.bak "s|@DEBUG_CXXFLAGS@|${FINAL_DEBUG_
 find . -name "*activate*.sh" -exec sed -i.bak "s|@LDFLAGS@|${FINAL_LDFLAGS}|g"                                                     "{}" \;
 find . -name "*activate*.sh" -exec sed -i.bak "s|@LDFLAGS_LD@|${FINAL_LDFLAGS_LD}|g"                                               "{}" \;
 find . -name "*activate*.sh" -exec sed -i.bak "s|@CONDA_BUILD_CROSS_COMPILATION@|${CONDA_BUILD_CROSS_COMPILATION}|g"                "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@_PYTHON_SYSCONFIGDATA_NAME@|${FINAL_PYTHON_SYSCONFIGDATA_NAME}|g"                 "{}" \;
 
 find . -name "*activate*.sh.bak" -exec rm "{}" \;
 

--- a/recipe/update-activate-and-repack.sh
+++ b/recipe/update-activate-and-repack.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+src="${SRC_DIR}/${PKG_NAME}"
+
+CBUILD=$(${PREFIX}/bin/icx -dumpmachine | sed "s/unknown/conda/")
+CHOST=$(${PREFIX}/bin/icx -dumpmachine | sed "s/unknown/conda/")
+
+FINAL_CFLAGS="-march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe"
+FINAL_DEBUG_CFLAGS="-march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -ffunction-sections -pipe"
+FINAL_CPPFLAGS="-DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -fuse-ld=lld"
+FINAL_DEBUG_CPPFLAGS="-D_DEBUG -D_FORTIFY_SOURCE=2 -Og -fuse-ld=lld"
+FINAL_CXXFLAGS="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe"
+FINAL_DEBUG_CXXFLAGS="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -ffunction-sections -pipe"
+FINAL_LDFLAGS="-Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,--disable-new-dtags -Wl,--gc-sections -fuse-ld=lld"
+FINAL_LDFLAGS_LD="-O2 --sort-common --as-needed -z relro -z now --disable-new-dtags --gc-sections -fuse-ld=lld"
+
+# if [[ "$target_platform" == "$ctng_target_platform" ]]; then
+#   export CONDA_BUILD_CROSS_COMPILATION=""
+# else
+#   export CONDA_BUILD_CROSS_COMPILATION="1"
+# fi
+# do not support cross compilation.
+export CONDA_BUILD_CROSS_COMPILATION=""
+
+pushd "${src}"
+
+find . -name "*activate*.sh" -exec sed -i.bak "s|@CBUILD@|${CBUILD}|g"                                                              "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@CHOST@|${CHOST}|g"                                                                "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@CFLAGS@|${FINAL_CFLAGS}|g"                                                       "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@DEBUG_CFLAGS@|${FINAL_DEBUG_CFLAGS}|g"                                           "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@CPPFLAGS@|${FINAL_CPPFLAGS}|g"                                                    "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@DEBUG_CPPFLAGS@|${FINAL_DEBUG_CPPFLAGS}|g"                                        "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@CXXFLAGS@|${FINAL_CXXFLAGS}|g"                                                   "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@DEBUG_CXXFLAGS@|${FINAL_DEBUG_CXXFLAGS}|g"                                       "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@LDFLAGS@|${FINAL_LDFLAGS}|g"                                                     "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@LDFLAGS_LD@|${FINAL_LDFLAGS_LD}|g"                                               "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@CONDA_BUILD_CROSS_COMPILATION@|${CONDA_BUILD_CROSS_COMPILATION}|g"                "{}" \;
+
+find . -name "*activate*.sh.bak" -exec rm "{}" \;
+
+popd
+
+# for subpackages, we have named our extracted locations according to the subpackage name
+#    That's what this $PKG_NAME is doing - picking the right subfolder to rsync
+
+cp -rv "${src}"/* "${PREFIX}/"
+
+# replace old info folder with our new regenerated one
+rm -rf "${PREFIX}/info"


### PR DESCRIPTION
These were the changes added to enable packages to be compiled with the provided Intel® oneAPI DPC++/C++ Compiler, namely `icx`/`icpx`.

I will update the changes with specific areas that need further review.