### PR TITLE
Release v2021.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "2021.3.0" %}
-{% set intel_build_number = "3350" %}  # [linux]
-{% set intel_build_number = "3375" %}  # [osx]
-{% set intel_build_number = "3372" %}  # [win]
+{% set version = "2021.4.0" %}
+{% set intel_build_number = "3561" %}  # [linux]
+{% set intel_build_number = "3538" %}  # [osx]
+{% set intel_build_number = "3556" %}  # [win]
 
-{% set oneccl_build_number = "343" %}
+{% set oneccl_build_number = "433" %}
 
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dst_build_number = '1' %}
+{% set dst_build_number = '0' %}
 
 package:
   name: intel-compiler-repack
@@ -45,7 +45,7 @@ build:
   number: {{ intel_build_number|int + dst_build_number|int }}
   binary_relocation: false
   detect_binary_files_with_prefix: false
-  skip: True                                  # [not (linux64 or win or osx)]
+  skip: True                                  # [not (x86 and (linux or win or osx))]
   missing_dso_whitelist:
     # these are binary repackages after all.
     # Note: any output that specifies a 'build' section will need to include this

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,8 @@ source:
     folder: intel-opencl-rt
   {% endif %}
   {% if linux64 or win64 %}
+  - url: https://anaconda.org/intel/dpl-include/{{ version }}/download/{{ target_platform }}/dpl-include-{{ version }}-intel_0.tar.bz2
+    folder: dpl-include
   - url: https://anaconda.org/intel/dpcpp_impl_{{ target_platform }}/{{ version }}/download/{{ target_platform }}/dpcpp_impl_{{ target_platform }}-{{ version }}-intel_{{ intel_build_number }}.tar.bz2
     folder: dpcpp_impl_{{ target_platform }}
   - url: https://anaconda.org/intel/dpcpp_{{ target_platform }}/{{ version }}/download/{{ target_platform }}/dpcpp_{{ target_platform }}-{{ version }}-intel_{{ intel_build_number }}.tar.bz2
@@ -205,6 +207,7 @@ outputs:
           - {{ pin_subpackage("dpcpp-cpp-rt", max_pin="x") }}
     requirements:
       run:
+        - dpl-include
         - {{ pin_subpackage('dpcpp-cpp-rt', exact=True) }}
 
     about:
@@ -288,6 +291,31 @@ outputs:
     test:
       commands:
         - ls -A1 $PREFIX/lib/*  # [unix]
+
+  - name: dpl-include
+    script: repack.sh   # [unix]
+    script: repack.bat  # [win]
+    build:
+      skip: True  # [not (linux64 or win64)]
+      missing_dso_whitelist:
+        - '*'
+    about:
+      home: https://software.intel.com/content/www/us/en/develop/tools.html
+      doc_url: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html
+      dev_url: https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top.html
+      summary: Intel® DPC++ Compilers (dpl component)
+      license: Intel End User License Agreement for Developer Tools
+      license_family: Proprietary
+      license_file:
+        - dpcpp_impl_{{ target_platform }}/info/licenses/license.txt  # [linux64 or win64]
+        - dpcpp_impl_{{ target_platform }}/info/licenses/tpp.txt      # [linux64 or win64]
+      description: |
+        Additional header files for Intel® oneAPI DPC++/C++ Compiler.
+        This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
+    test:
+      commands:
+        - ls -A1 ${PREFIX}/include/oneapi/*     # [unix]
+        - dir %PREFIX%\Library\include\oneapi\*  # [win]
 
 about:
   home: https://github.com/AnacondaRecipes/intel-compilers-repack-feedstock


### PR DESCRIPTION
Release v2021.4.0 also includes `dpl-include` with some missing header files for the DPC++/C++ compilers. This should only be needed for this release and can be reverted during the update to the next release.