### PR TITLE
Updated meta.yaml for 2022.1 sources

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,16 @@
-{% set version = "2022.0.1" %}          # [linux]
-{% set version = "2022.0.0" %}          # [osx or win]
-{% set intel_build_number = "3633" %}   # [linux]
-{% set intel_build_number = "3615" %}   # [osx]
-{% set intel_build_number = "3663" %}   # [win]
+{% set version = "2022.1.0" %}          # [linux]
+{% set version = "2022.1.0" %}          # [osx or win]
+{% set intel_build_number = "3768" %}   # [linux]
+{% set intel_build_number = "3718" %}   # [osx]
+{% set intel_build_number = "3787" %}   # [win]
 
 {% set oneccl_version = "2021.5.0" %}
 {% set oneccl_build_number = "478" %}
 
-{% set tbb_version = "2021.5.0" %}
+{% set tbb_version = "2021.6.0" %}
 
-{% set mkl_dpcpp_build_number = "117" %}  # [linux]
-{% set mkl_dpcpp_build_number = "115" %}  # [win]
+{% set mkl_dpcpp_build_number = "223" %}  # [linux]
+{% set mkl_dpcpp_build_number = "192" %}  # [win]
 
 # use this if our build script changes and we need to increment beyond intel's version
 {% set dst_build_number = '0' %}


### PR DESCRIPTION
This PR updates the `meta.yaml` with versions and build numbers for 2022.1 release of oneAPI compilers. 

This is parallel to changes in conda-forge/intel-compiler-repack-feedstock#4

