### PR TITLE
Update to 2022.1.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,6 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
   - "--error-overdepending"
+
+channels: 
+  cbouss: dpcpp

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,6 +3,3 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
   - "--error-overdepending"
-
-channels: 
-  cbouss: dpcpp

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+CHOST:                                              # [linux and x86]
+  - x86_64-conda-linux-gnu                          # [linux and x86]
+FINAL_PYTHON_SYSCONFIGDATA_NAME:                    # [linux and x86]
+  - _sysconfigdata_x86_64_conda_linux_gnu           # [linux and x86]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
-CHOST:                                              # [linux and x86]
-  - x86_64-conda-linux-gnu                          # [linux and x86]
-FINAL_PYTHON_SYSCONFIGDATA_NAME:                    # [linux and x86]
-  - _sysconfigdata_x86_64_conda_linux_gnu           # [linux and x86]
+CHOST:                                              # [linux]
+  - x86_64-conda-linux-gnu                          # [linux]
+FINAL_PYTHON_SYSCONFIGDATA_NAME:                    # [linux]
+  - _sysconfigdata_x86_64_conda_linux_gnu           # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,8 @@ source:
     folder: dpcpp_impl_{{ target_platform }}
   - url: https://anaconda.org/intel/dpcpp_{{ target_platform }}/{{ version }}/download/{{ target_platform }}/dpcpp_{{ target_platform }}-{{ version }}-intel_{{ intel_build_number }}.tar.bz2
     folder: dpcpp_{{ target_platform }}
+    patches:
+      - patches/0001-dpcpp-activation.patch
   - url: https://anaconda.org/intel/mkl-dpcpp/{{ version }}/download/{{ target_platform }}/mkl-dpcpp-{{ version }}-intel_{{ mkl_dpcpp_build_number }}.tar.bz2
     folder: mkl-dpcpp
   - url: https://anaconda.org/intel/mkl-devel-dpcpp/{{ version }}/download/{{ target_platform }}/mkl-devel-dpcpp-{{ version }}-intel_{{ mkl_dpcpp_build_number }}.tar.bz2
@@ -62,6 +64,11 @@ build:
     # Note: any output that specifies a 'build' section will need to include this
     # because it gets overwritten? what about binary_relocation / detect_binary_files_with_prefix?
     - '*'
+
+requirements:
+  build:
+    - patch     # [unix]
+    - m2-patch  # [win]
 
 outputs:
   - name: intel-cmplr-lic-rt
@@ -213,10 +220,18 @@ outputs:
         # 1. strong so if gets added if this package is in the build requirement section.
         # 2. Pin to year for now, similar to MKL.
         strong:
-          - {{ pin_subpackage("dpcpp-cpp-rt", max_pin="x") }}
+          - {{ pin_subpackage("dpcpp-cpp-rt", max_pin="x") }}          
+          - libgcc-ng >={{ c_compiler_version }}
+          - libstdcxx-ng >={{ cxx_compiler_version }}
     requirements:
       run:
-        - {{ pin_subpackage('dpcpp-cpp-rt', exact=True) }}
+        - {{ pin_subpackage('dpcpp-cpp-rt', exact=True) }}        
+        # compiler's need a sysroot "/"
+        - sysroot_{{ target_platform }}   # [linux]
+        # targets --rtlib=libgcc because compiler-rt builtins is not provided.
+        - gcc_impl_{{ target_platform }}  # [linux]
+        # these binaries target -stdlib=libstdc++
+        - gxx_impl_{{ target_platform }}  # [linux]
 
     about:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
@@ -239,9 +254,9 @@ outputs:
         - dir %PREFIX%\Library\bin\*  # [win]
         - dir %PREFIX%\Library\lib\*  # [win]
 
-  - name: dpcpp_{{ target_platform }}
-    script: repack.sh   # [unix]
-    script: repack.bat  # [win]
+  - name: dpcpp_{{ target_platform }}    
+    script: update-activate-and-repack.sh   # [unix]
+    script: repack.bat                      # [win]
     build:
       skip: True  # [not (linux or win64)]
       missing_dso_whitelist:
@@ -250,8 +265,13 @@ outputs:
         # 1. strong so if gets added if this package is in the build requirement section.
         # 2. Pin to year for now, similar to MKL.
         strong:
-          - {{ pin_subpackage("dpcpp-cpp-rt", max_pin="x") }}
+          - {{ pin_subpackage("dpcpp-cpp-rt", max_pin="x") }}          
+          - libgcc-ng >={{ c_compiler_version }}
+          - libstdcxx-ng >={{ cxx_compiler_version }}
     requirements:   # [linux or win64]
+      # for us to be able to use clang/icx -dumpmachine
+      build:        # [linux or win64]
+        - dpcpp_impl_{{ target_platform }}  # [linux or win64]
       run:          # [linux or win64]
         - {{ pin_subpackage('dpcpp_impl_linux-64', exact=True) }} # [linux]
         - {{ pin_subpackage('dpcpp_impl_win-64', exact=True) }}   # [win64]
@@ -259,7 +279,7 @@ outputs:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
       doc_url: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html
       dev_url: https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top.html
-      summary: Implementation for Intel® oneAPI DPC++/C++ Compiler
+      summary: Activation for Intel® oneAPI DPC++/C++ Compiler
       license: Intel End User License Agreement for Developer Tools
       license_family: Proprietary
       license_file:                                                   # [linux or win64]
@@ -280,7 +300,7 @@ outputs:
         - ls -A1 ${PREFIX}/lib/*         # [unix]
         - dir %PREFIX%\Library\bin\*  # [win]
         - dir %PREFIX%\Library\lib\*  # [win]
-        - dpcpp --gcc-toolchain=$PREFIX --sysroot=$PREFIX/$HOST/sysroot -target $HOST ${LDFLAGS} ${CXXFLAGS} simple.cpp -lpthread -o simple.exe  # [unix]
+        - dpcpp --gcc-toolchain=$PREFIX --sysroot=$PREFIX/$HOST/sysroot -target $HOST ${LDFLAGS} ${CXXFLAGS} simple.cpp -lpthread -o simple  # [unix]
         # Need for -I option is a bug in compiler activation script. Can be removed when fixed
         - dpcpp simple.cpp -I%PREFIX%\include -o simple.exe  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -221,8 +221,8 @@ outputs:
         # 2. Pin to year for now, similar to MKL.
         strong:
           - {{ pin_subpackage("dpcpp-cpp-rt", max_pin="x") }}          
-          - libgcc-ng >={{ c_compiler_version }}
-          - libstdcxx-ng >={{ cxx_compiler_version }}
+          - libgcc-ng >={{ c_compiler_version }}      # [linux]
+          - libstdcxx-ng >={{ cxx_compiler_version }} # [linux]
     requirements:
       run:
         - {{ pin_subpackage('dpcpp-cpp-rt', exact=True) }}        
@@ -266,8 +266,8 @@ outputs:
         # 2. Pin to year for now, similar to MKL.
         strong:
           - {{ pin_subpackage("dpcpp-cpp-rt", max_pin="x") }}          
-          - libgcc-ng >={{ c_compiler_version }}
-          - libstdcxx-ng >={{ cxx_compiler_version }}
+          - libgcc-ng >={{ c_compiler_version }}      # [linux]
+          - libstdcxx-ng >={{ cxx_compiler_version }} # [linux]
     requirements:   # [linux or win64]
       # for us to be able to use clang/icx -dumpmachine
       build:        # [linux or win64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ source:
   - url: https://anaconda.org/intel/dpcpp_{{ target_platform }}/{{ version }}/download/{{ target_platform }}/dpcpp_{{ target_platform }}-{{ version }}-intel_{{ intel_build_number }}.tar.bz2
     folder: dpcpp_{{ target_platform }}
     patches:
-      - patches/0001-dpcpp-activation.patch
+      - patches/0001-dpcpp-activation.patch # [linux]
   - url: https://anaconda.org/intel/mkl-dpcpp/{{ version }}/download/{{ target_platform }}/mkl-dpcpp-{{ version }}-intel_{{ mkl_dpcpp_build_number }}.tar.bz2
     folder: mkl-dpcpp
   - url: https://anaconda.org/intel/mkl-devel-dpcpp/{{ version }}/download/{{ target_platform }}/mkl-devel-dpcpp-{{ version }}-intel_{{ mkl_dpcpp_build_number }}.tar.bz2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -301,7 +301,6 @@ outputs:
         - dir %PREFIX%\Library\bin\*  # [win]
         - dir %PREFIX%\Library\lib\*  # [win]
         - icpx --dpcpp -fsycl --gcc-toolchain=$PREFIX --sysroot=$PREFIX/$HOST/sysroot -target $HOST ${LDFLAGS} ${CXXFLAGS} simple.cpp -lpthread -o simple  # [unix]
-        - ./simple # [unix]
         # Need for -I option is a bug in compiler activation script. Can be removed when fixed
         - dpcpp simple.cpp -I%PREFIX%\include -o simple.exe  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -300,7 +300,8 @@ outputs:
         - ls -A1 ${PREFIX}/lib/*         # [unix]
         - dir %PREFIX%\Library\bin\*  # [win]
         - dir %PREFIX%\Library\lib\*  # [win]
-        - dpcpp --gcc-toolchain=$PREFIX --sysroot=$PREFIX/$HOST/sysroot -target $HOST ${LDFLAGS} ${CXXFLAGS} simple.cpp -lpthread -o simple  # [unix]
+        - icpx --dpcpp -fsycl --gcc-toolchain=$PREFIX --sysroot=$PREFIX/$HOST/sysroot -target $HOST ${LDFLAGS} ${CXXFLAGS} simple.cpp -lpthread -o simple  # [unix]
+        - ./simple # [unix]
         # Need for -I option is a bug in compiler activation script. Can be removed when fixed
         - dpcpp simple.cpp -I%PREFIX%\include -o simple.exe  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,16 @@
-{% set version = "2022.0.1" %}          # [linux]
-{% set version = "2022.0.0" %}          # [osx or win]
-{% set intel_build_number = "3633" %}   # [linux]
-{% set intel_build_number = "3615" %}   # [osx]
-{% set intel_build_number = "3663" %}   # [win]
+{% set version = "2022.1.0" %}          # [linux]
+{% set version = "2022.1.0" %}          # [osx or win]
+{% set intel_build_number = "3768" %}   # [linux]
+{% set intel_build_number = "3718" %}   # [osx]
+{% set intel_build_number = "3787" %}   # [win]
 
 {% set oneccl_version = "2021.5.0" %}
 {% set oneccl_build_number = "478" %}
 
-{% set tbb_version = "2021.5.0" %}
+{% set tbb_version = "2021.6.0" %}
 
-{% set mkl_dpcpp_build_number = "117" %}  # [linux]
-{% set mkl_dpcpp_build_number = "115" %}  # [win]
+{% set mkl_dpcpp_build_number = "223" %}  # [linux]
+{% set mkl_dpcpp_build_number = "192" %}  # [win]
 
 # use this if our build script changes and we need to increment beyond intel's version
 {% set dst_build_number = '0' %}
@@ -37,7 +37,7 @@ source:
   - url: https://anaconda.org/intel/intel-opencl-rt/{{ version }}/download/{{ target_platform }}/intel-opencl-rt-{{ version }}-intel_{{ intel_build_number }}.tar.bz2
     folder: intel-opencl-rt
   {% endif %}
-  {% if linux64 or win64 %}
+  {% if linux or win64 %}
   - url: https://anaconda.org/intel/dpcpp_impl_{{ target_platform }}/{{ version }}/download/{{ target_platform }}/dpcpp_impl_{{ target_platform }}-{{ version }}-intel_{{ intel_build_number }}.tar.bz2
     folder: dpcpp_impl_{{ target_platform }}
   - url: https://anaconda.org/intel/dpcpp_{{ target_platform }}/{{ version }}/download/{{ target_platform }}/dpcpp_{{ target_platform }}-{{ version }}-intel_{{ intel_build_number }}.tar.bz2
@@ -47,7 +47,7 @@ source:
   - url: https://anaconda.org/intel/mkl-devel-dpcpp/{{ version }}/download/{{ target_platform }}/mkl-devel-dpcpp-{{ version }}-intel_{{ mkl_dpcpp_build_number }}.tar.bz2
     folder: mkl-devel-dpcpp
   {% endif %}
-  {% if linux64 %}
+  {% if linux %}
   - url: https://anaconda.org/intel/oneccl-devel/{{ oneccl_version }}/download/{{ target_platform }}/oneccl-devel-{{ oneccl_version }}-intel_{{ oneccl_build_number }}.tar.bz2
     folder: oneccl-devel
   {% endif %}
@@ -206,7 +206,7 @@ outputs:
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:
-      skip: True  # [not (linux64 or win64)]
+      skip: True  # [not (linux or win64)]
       missing_dso_whitelist:
         - '*'
       run_exports:
@@ -226,8 +226,8 @@ outputs:
       license: Intel End User License Agreement for Developer Tools
       license_family: Proprietary
       license_file: 
-        - dpcpp_impl_{{ target_platform }}/info/licenses/license.txt  # [linux64 or win64]
-        - dpcpp_impl_{{ target_platform }}/info/licenses/tpp.txt      # [linux64 or win64]
+        - dpcpp_impl_{{ target_platform }}/info/licenses/license.txt  # [linux or win64]
+        - dpcpp_impl_{{ target_platform }}/info/licenses/tpp.txt      # [linux or win64]
       description: |
         Implementation for Intel® oneAPI DPC++/C++ Compiler.
         This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
@@ -243,7 +243,7 @@ outputs:
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:
-      skip: True  # [not (linux64 or win64)]
+      skip: True  # [not (linux or win64)]
       missing_dso_whitelist:
         - '*'
       run_exports:
@@ -251,9 +251,9 @@ outputs:
         # 2. Pin to year for now, similar to MKL.
         strong:
           - {{ pin_subpackage("dpcpp-cpp-rt", max_pin="x") }}
-    requirements:   # [linux64 or win64]
-      run:          # [linux64 or win64]
-        - {{ pin_subpackage('dpcpp_impl_linux-64', exact=True) }} # [linux64]
+    requirements:   # [linux or win64]
+      run:          # [linux or win64]
+        - {{ pin_subpackage('dpcpp_impl_linux-64', exact=True) }} # [linux]
         - {{ pin_subpackage('dpcpp_impl_win-64', exact=True) }}   # [win64]
     about:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
@@ -262,26 +262,34 @@ outputs:
       summary: Implementation for Intel® oneAPI DPC++/C++ Compiler
       license: Intel End User License Agreement for Developer Tools
       license_family: Proprietary
-      license_file:                                                   # [linux64 or win64]
-        - dpcpp_impl_{{ target_platform }}/info/licenses/license.txt  # [linux64 or win64]
-        - dpcpp_impl_{{ target_platform }}/info/licenses/tpp.txt      # [linux64 or win64]
+      license_file:                                                   # [linux or win64]
+        - dpcpp_impl_{{ target_platform }}/info/licenses/license.txt  # [linux or win64]
+        - dpcpp_impl_{{ target_platform }}/info/licenses/tpp.txt      # [linux or win64]
       description: |
         Activation for Intel® oneAPI DPC++/C++ Compiler.
         This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
     test:
+      requires:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      files:
+        - simple.cpp
       commands:
         - ls -A1 ${PREFIX}/bin/*         # [unix]
         - ls -A1 ${PREFIX}/include/*     # [unix]
         - ls -A1 ${PREFIX}/lib/*         # [unix]
         - dir %PREFIX%\Library\bin\*  # [win]
         - dir %PREFIX%\Library\lib\*  # [win]
+        - dpcpp --gcc-toolchain=$PREFIX --sysroot=$PREFIX/$HOST/sysroot -target $HOST ${LDFLAGS} ${CXXFLAGS} simple.cpp -lpthread -o simple.exe  # [unix]
+        # Need for -I option is a bug in compiler activation script. Can be removed when fixed
+        - dpcpp simple.cpp -I%PREFIX%\include -o simple.exe  # [win]
 
   - name: oneccl-devel
     version: {{ oneccl_version }}
     script: repack.sh   # [unix]
     build:
       number: {{ oneccl_build_number|int + dst_build_number|int }}
-      skip: True  # [not linux64]
+      skip: True  # [not linux]
       missing_dso_whitelist:
         - '*'
     about:
@@ -302,11 +310,11 @@ outputs:
         - ls -A1 $PREFIX/lib/*  # [unix]
 
   - name: mkl-dpcpp
-    script: repack.sh   # [linux64]
+    script: repack.sh   # [linux]
     script: repack.bat  # [win64]
     build:
-      number: {{ mkl_dpcpp_build_number|int + dst_build_number|int }}   # [linux64 or win64]
-      skip: True  # [not (linux64 or win64)]
+      number: {{ mkl_dpcpp_build_number|int + dst_build_number|int }}   # [linux or win64]
+      skip: True  # [not (linux or win64)]
       missing_dso_whitelist:
         - '*'
     requirements:
@@ -335,15 +343,15 @@ outputs:
         <br/> Third Party Programs: Included in software package <br/><br/>
     test:
       commands:
-        - ls -A1 ${PREFIX}/lib/*        # [linux64]
+        - ls -A1 ${PREFIX}/lib/*        # [linux]
         - dir %PREFIX%\Library\lib\*    # [win64]
 
   - name: mkl-devel-dpcpp
-    script: repack.sh   # [linux64]
+    script: repack.sh   # [linux]
     script: repack.bat  # [win64]
     build:
-      number: {{ mkl_dpcpp_build_number|int + dst_build_number|int }}   # [linux64 or win64]
-      skip: True  # [not (linux64 or win64)]
+      number: {{ mkl_dpcpp_build_number|int + dst_build_number|int }}   # [linux or win64]
+      skip: True  # [not (linux or win64)]
       missing_dso_whitelist:
         - '*'
       run_exports:
@@ -373,8 +381,8 @@ outputs:
         <br/> Third Party Programs: Included in software package <br/><br/>
     test:
       commands:
-        - ls -A1 ${PREFIX}/lib/*            # [linux64]
-        - ls -A1 ${PREFIX}/include/*        # [linux64]
+        - ls -A1 ${PREFIX}/lib/*            # [linux]
+        - ls -A1 ${PREFIX}/include/*        # [linux]
         - dir %PREFIX%\Library\include\*    # [win64]
         - dir %PREFIX%\Library\lib\*        # [win64]
 
@@ -385,4 +393,6 @@ about:
 
 extra:
   recipe-maintainers:
-    - 
+    - napetrov
+    - tomashek
+    - oleksandr-pavlyk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,24 +25,22 @@ source:
     folder: intel-cmplr-lic-rt
   - url: https://anaconda.org/intel/intel-fortran-rt/{{ version }}/download/{{ target_platform }}/intel-fortran-rt-{{ version }}-intel_{{ intel_build_number }}.tar.bz2
     folder: intel-fortran-rt
-  {% if not win32 %}
   - url: https://anaconda.org/intel/dpcpp-cpp-rt/{{ version }}/download/{{ target_platform }}/dpcpp-cpp-rt-{{ version }}-intel_{{ intel_build_number }}.tar.bz2
     folder: dpcpp-cpp-rt
-  {% endif %}
   {% if not osx %}
   - url: https://anaconda.org/intel/intel-cmplr-lib-rt/{{ version }}/download/{{ target_platform }}/intel-cmplr-lib-rt-{{ version }}-intel_{{ intel_build_number }}.tar.bz2 
     folder: intel-cmplr-lib-rt
   {% endif %}
-  {% if not (osx or win32) %}
+  {% if not (osx) %}
   - url: https://anaconda.org/intel/intel-opencl-rt/{{ version }}/download/{{ target_platform }}/intel-opencl-rt-{{ version }}-intel_{{ intel_build_number }}.tar.bz2
     folder: intel-opencl-rt
   {% endif %}
-  {% if linux or win64 %}
+  {% if linux or win %}
   - url: https://anaconda.org/intel/dpcpp_impl_{{ target_platform }}/{{ version }}/download/{{ target_platform }}/dpcpp_impl_{{ target_platform }}-{{ version }}-intel_{{ intel_build_number }}.tar.bz2
     folder: dpcpp_impl_{{ target_platform }}
   - url: https://anaconda.org/intel/dpcpp_{{ target_platform }}/{{ version }}/download/{{ target_platform }}/dpcpp_{{ target_platform }}-{{ version }}-intel_{{ intel_build_number }}.tar.bz2
     folder: dpcpp_{{ target_platform }}
-    patches:
+    patches:                                # [linux]
       - patches/0001-dpcpp-activation.patch # [linux]
   - url: https://anaconda.org/intel/mkl-dpcpp/{{ version }}/download/{{ target_platform }}/mkl-dpcpp-{{ version }}-intel_{{ mkl_dpcpp_build_number }}.tar.bz2
     folder: mkl-dpcpp
@@ -58,7 +56,7 @@ build:
   number: {{ intel_build_number|int + dst_build_number|int }}
   binary_relocation: false
   detect_binary_files_with_prefix: false
-  skip: True                                  # [not (x86 and (linux or win or osx))]
+  skip: True                                  # [not x86]
   missing_dso_whitelist:
     # these are binary repackages after all.
     # Note: any output that specifies a 'build' section will need to include this
@@ -121,7 +119,7 @@ outputs:
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:
-      skip: True  # [win32 or osx]
+      skip: True  # [osx]
       missing_dso_whitelist:
         - '*'
     requirements:
@@ -213,7 +211,7 @@ outputs:
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:
-      skip: True  # [not (linux or win64)]
+      skip: True  # [not (linux or win)]
       missing_dso_whitelist:
         - '*'
       run_exports:
@@ -225,7 +223,7 @@ outputs:
           - libstdcxx-ng >={{ cxx_compiler_version }} # [linux]
     requirements:
       run:
-        - {{ pin_subpackage('dpcpp-cpp-rt', exact=True) }}        
+        - {{ pin_subpackage('dpcpp-cpp-rt', exact=True) }}
         # compiler's need a sysroot "/"
         - sysroot_{{ target_platform }}   # [linux]
         # targets --rtlib=libgcc because compiler-rt builtins is not provided.
@@ -241,8 +239,8 @@ outputs:
       license: Intel End User License Agreement for Developer Tools
       license_family: Proprietary
       license_file: 
-        - dpcpp_impl_{{ target_platform }}/info/licenses/license.txt  # [linux or win64]
-        - dpcpp_impl_{{ target_platform }}/info/licenses/tpp.txt      # [linux or win64]
+        - dpcpp_impl_{{ target_platform }}/info/licenses/license.txt  # [linux or win]
+        - dpcpp_impl_{{ target_platform }}/info/licenses/tpp.txt      # [linux or win]
       description: |
         Implementation for Intel® oneAPI DPC++/C++ Compiler.
         This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
@@ -254,27 +252,27 @@ outputs:
         - dir %PREFIX%\Library\bin\*  # [win]
         - dir %PREFIX%\Library\lib\*  # [win]
 
-  - name: dpcpp_{{ target_platform }}    
+  - name: dpcpp_{{ target_platform }}
     script: update-activate-and-repack.sh   # [unix]
     script: repack.bat                      # [win]
     build:
-      skip: True  # [not (linux or win64)]
+      skip: True  # [not (linux or win)]
       missing_dso_whitelist:
         - '*'
       run_exports:
         # 1. strong so if gets added if this package is in the build requirement section.
         # 2. Pin to year for now, similar to MKL.
         strong:
-          - {{ pin_subpackage("dpcpp-cpp-rt", max_pin="x") }}          
+          - {{ pin_subpackage("dpcpp-cpp-rt", max_pin="x") }}
           - libgcc-ng >={{ c_compiler_version }}      # [linux]
           - libstdcxx-ng >={{ cxx_compiler_version }} # [linux]
-    requirements:   # [linux or win64]
+    requirements:   # [linux or win]
       # for us to be able to use clang/icx -dumpmachine
-      build:        # [linux or win64]
-        - dpcpp_impl_{{ target_platform }}  # [linux or win64]
-      run:          # [linux or win64]
+      build:        # [linux or win]
+        - dpcpp_impl_{{ target_platform }}  # [linux or win]
+      run:          # [linux or win]
         - {{ pin_subpackage('dpcpp_impl_linux-64', exact=True) }} # [linux]
-        - {{ pin_subpackage('dpcpp_impl_win-64', exact=True) }}   # [win64]
+        - {{ pin_subpackage('dpcpp_impl_win-64', exact=True) }}   # [win]
     about:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
       doc_url: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html
@@ -282,9 +280,9 @@ outputs:
       summary: Activation for Intel® oneAPI DPC++/C++ Compiler
       license: Intel End User License Agreement for Developer Tools
       license_family: Proprietary
-      license_file:                                                   # [linux or win64]
-        - dpcpp_impl_{{ target_platform }}/info/licenses/license.txt  # [linux or win64]
-        - dpcpp_impl_{{ target_platform }}/info/licenses/tpp.txt      # [linux or win64]
+      license_file:                                                   # [linux or win]
+        - dpcpp_impl_{{ target_platform }}/info/licenses/license.txt  # [linux or win]
+        - dpcpp_impl_{{ target_platform }}/info/licenses/tpp.txt      # [linux or win]
       description: |
         Activation for Intel® oneAPI DPC++/C++ Compiler.
         This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
@@ -331,10 +329,10 @@ outputs:
 
   - name: mkl-dpcpp
     script: repack.sh   # [linux]
-    script: repack.bat  # [win64]
+    script: repack.bat  # [win]
     build:
-      number: {{ mkl_dpcpp_build_number|int + dst_build_number|int }}   # [linux or win64]
-      skip: True  # [not (linux or win64)]
+      number: {{ mkl_dpcpp_build_number|int + dst_build_number|int }}   # [linux or win]
+      skip: True  # [not (linux or win)]
       missing_dso_whitelist:
         - '*'
     requirements:
@@ -364,14 +362,14 @@ outputs:
     test:
       commands:
         - ls -A1 ${PREFIX}/lib/*        # [linux]
-        - dir %PREFIX%\Library\lib\*    # [win64]
+        - dir %PREFIX%\Library\lib\*    # [win]
 
   - name: mkl-devel-dpcpp
     script: repack.sh   # [linux]
-    script: repack.bat  # [win64]
+    script: repack.bat  # [win]
     build:
-      number: {{ mkl_dpcpp_build_number|int + dst_build_number|int }}   # [linux or win64]
-      skip: True  # [not (linux or win64)]
+      number: {{ mkl_dpcpp_build_number|int + dst_build_number|int }}   # [linux or win]
+      skip: True  # [not (linux or win)]
       missing_dso_whitelist:
         - '*'
       run_exports:
@@ -403,8 +401,8 @@ outputs:
       commands:
         - ls -A1 ${PREFIX}/lib/*            # [linux]
         - ls -A1 ${PREFIX}/include/*        # [linux]
-        - dir %PREFIX%\Library\include\*    # [win64]
-        - dir %PREFIX%\Library\lib\*        # [win64]
+        - dir %PREFIX%\Library\include\*    # [win]
+        - dir %PREFIX%\Library\lib\*        # [win]
 
 about:
   home: https://github.com/AnacondaRecipes/intel-compilers-repack-feedstock

--- a/recipe/patches/0001-dpcpp-activation.patch
+++ b/recipe/patches/0001-dpcpp-activation.patch
@@ -1,0 +1,138 @@
+diff --git a/etc/conda/activate.d/activate-dpcpp.sh b/etc/conda/activate.d/activate-dpcpp.sh
+index c21165a..cbbc756 100755
+--- a/etc/conda/activate.d/activate-dpcpp.sh
++++ b/etc/conda/activate.d/activate-dpcpp.sh
+@@ -83,12 +83,40 @@ function _tc_activation() {
+   return 0
+ }
+ 
++CONDA_BUILD_SYSROOT_USED="${CONDA_PREFIX}/@CHOST@/sysroot"
++
++_CMAKE_ARGS="-DCMAKE_AR=${CONDA_PREFIX}/bin/@CHOST@-llvm-ar -DCMAKE_CXX_COMPILER_AR=${CONDA_PREFIX}/bin/@CHOST@-llvm-ar -DCMAKE_C_COMPILER_AR=${CONDA_PREFIX}/bin/@CHOST@-llvm-ar"
++_CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_RANLIB=${CONDA_PREFIX}/bin/@CHOST@-llvm-ranlib -DCMAKE_CXX_COMPILER_RANLIB=${CONDA_PREFIX}/bin/@CHOST@-llvm-ranlib -DCMAKE_C_COMPILER_RANLIB=${CONDA_PREFIX}/bin/@CHOST@-llvm-ranlib"
++_CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_LINKER=${CONDA_PREFIX}/bin/@CHOST@-ld.lld"
+ 
+ if [ "${CONDA_BUILD:-0}" = "1" ]; then
++  # add some more CMAKE stuff first.
++  _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY"
++  _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_FIND_ROOT_PATH=${PREFIX};${BUILD_PREFIX}/@CHOST@/sysroot"
++  _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=lib"
++
++  CFLAGS_USED="@CFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  DEBUG_CFLAGS_USED="@CFLAGS@ @DEBUG_CFLAGS@  --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  CPPFLAGS_USED="@CPPFLAGS@ -isystem ${PREFIX}/include"
++  DEBUG_CPPFLAGS_USED="@DEBUG_CPPFLAGS@ -isystem ${PREFIX}/include"
++  CXXFLAGS_USED="@CXXFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  DEBUG_CXXFLAGS_USED="@CXXFLAGS@ @DEBUG_CXXFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  LDFLAGS_USED="@LDFLAGS@ --target=@CHOST@ -Wl,-rpath,${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib -Wl,-rpath,${BUILD_PREFIX}/lib -Wl,-rpath-link,${BUILD_PREFIX}/lib -L${BUILD_PREFIX}/lib"
++  LDFLAGS_LD_USED="@LDFLAGS_LD@ --target=@CHOST@ -rpath ${PREFIX}/lib -rpath-link ${PREFIX}/lib -L${PREFIX}/lib -rpath ${BUILD_PREFIX}/lib -rpath-link ${BUILD_PREFIX}/lib -L${BUILD_PREFIX}/lib"
++  CMAKE_PREFIX_PATH_USED="${PREFIX}:${CONDA_PREFIX}/@CHOST@/sysroot/usr"
+   CPATH_USED="${PREFIX}/include:${CONDA_PREFIX}"
+   LIBRARY_PATH_USED="${PREFIX}/compiler/lib:${LIBRARY_PATH}"
+   LD_LIBRARY_PATH_USED="${PREFIX}/compiler/lib/intel64_lin:${PREFIX}/compiler/lib:${PREFIX}/lib:${LD_LIBRARY_PATH}"
+ else
++  CFLAGS_USED="@CFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  DEBUG_CFLAGS_USED="@DEBUG_CFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  CPPFLAGS_USED="@CPPFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  DEBUG_CPPFLAGS_USED="@DEBUG_CPPFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  CXXFLAGS_USED="@CXXFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  DEBUG_CXXFLAGS_USED="@DEBUG_CXXFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  LDFLAGS_USED="@LDFLAGS@ -Wl,-rpath,${CONDA_PREFIX}/lib -Wl,-rpath-link,${CONDA_PREFIX}/lib -L${CONDA_PREFIX}/lib"
++  LDFLAGS_LD_USED="@LDFLAGS_LD@ -rpath ${CONDA_PREFIX}/lib -rpath-link ${CONDA_PREFIX}/lib -L${CONDA_PREFIX}/lib"
++  CMAKE_PREFIX_PATH_USED="${CONDA_PREFIX}:${CONDA_PREFIX}/@CHOST@/sysroot/usr"
+   CPATH_USED="${CONDA_PREFIX}/include:${CONDA_PREFIX}"
+   LIBRARY_PATH_USED="${CONDA_PREFIX}/compiler/lib:${LIBRARY_PATH}"
+   LD_LIBRARY_PATH_USED="${CONDA_PREFIX}/compiler/lib/intel64_lin:${CONDA_PREFIX}/compiler/lib:${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"
+@@ -103,10 +131,30 @@ fi
+ 
+ _tc_activation \
+   activate @CHOST@- "HOST,@CHOST@" "BUILD,@CBUILD@" \
++  "CC,${CC:-@CHOST@-icx}" \
++  "CXX,${CXX:-@CHOST@-icpx}" \
++  "LD,${LD:-@CHOST@-ld.lld}" \
++  "AR,${AR:-@CHOST@-llvm-ar}" \
++  "RANLIB,${RANLIB:-@CHOST@-llvm-ranlib}" \
++  "CFLAGS,${CFLAGS:-${CFLAGS_USED}}" \
++  "DEBUG_CFLAGS,${DEBUG_CFLAGS:-${DEBUG_CFLAGS_USED}}" \
++  "CPPFLAGS,${CPPFLAGS:-${CPPFLAGS_USED}}" \
++  "DEBUG_CPPFLAGS,${DEBUG_CPPFLAGS:-${DEBUG_CPPFLAGS_USED}}" \
++  "CXXFLAGS,${CXXFLAGS:-${CXXFLAGS_USED}}" \
++  "DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-${DEBUG_CXXFLAGS_USED}}" \
++  "LDFLAGS,${LDFLAGS:-${LDFLAGS_USED}}" \
++  "LDFLAGS_LD,${LDFLAGS_LD:-${LDFLAGS_LD_USED}}" \
++  "CONDA_BUILD_SYSROOT,${CONDA_BUILD_SYSROOT_USED:-}" \
++  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME:-@_PYTHON_SYSCONFIGDATA_NAME@}" \
++  "CMAKE_ARGS,${_CMAKE_ARGS:-}" \
++  "CONDA_BUILD_CROSS_COMPILATION,@CONDA_BUILD_CROSS_COMPILATION@" \
++  "CMAKE_PREFIX_PATH,${CMAKE_PREFIX_PATH_USED}" \
+   "CPATH,${CPATH:-${CPATH_USED}}" \
+   "LIBRARY_PATH,${LIBRARY_PATH:-${LIBRARY_PATH_USED}}" \
+   "LD_LIBRARY_PATH,${LD_LIBRARY_PATH:-${LD_LIBRARY_PATH_USED}}"
+ 
++unset _CMAKE_ARGS
++
+ if [ $? -ne 0 ]; then
+   echo "ERROR: $(_get_sourced_filename) failed, see above for details"
+ else
+diff --git a/etc/conda/deactivate.d/deactivate-dpcpp.sh b/etc/conda/deactivate.d/deactivate-dpcpp.sh
+index 6975b03..a4ff33f 100755
+--- a/etc/conda/deactivate.d/deactivate-dpcpp.sh
++++ b/etc/conda/deactivate.d/deactivate-dpcpp.sh
+@@ -83,11 +83,32 @@ function _tc_activation() {
+   return 0
+ }
+ 
++CONDA_BUILD_SYSROOT_USED="${CONDA_PREFIX}/@CHOST@/sysroot"
++
+ if [ "${CONDA_BUILD:-0}" = "1" ]; then
++
++  CFLAGS_USED="@CFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  DEBUG_CFLAGS_USED="@CFLAGS@ @DEBUG_CFLAGS@  --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  CPPFLAGS_USED="@CPPFLAGS@ -isystem ${PREFIX}/include"
++  DEBUG_CPPFLAGS_USED="@DEBUG_CPPFLAGS@ -isystem ${PREFIX}/include"
++  CXXFLAGS_USED="@CXXFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  DEBUG_CXXFLAGS_USED="@CXXFLAGS@ @DEBUG_CXXFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  LDFLAGS_USED="@LDFLAGS@ --target=@CHOST@ -Wl,-rpath,${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib -Wl,-rpath,${BUILD_PREFIX}/lib -Wl,-rpath-link,${BUILD_PREFIX}/lib -L${BUILD_PREFIX}/lib"
++  LDFLAGS_LD_USED="@LDFLAGS_LD@ --target=@CHOST@ -rpath ${PREFIX}/lib -rpath-link ${PREFIX}/lib -L${PREFIX}/lib -rpath ${BUILD_PREFIX}/lib -rpath-link ${BUILD_PREFIX}/lib -L${BUILD_PREFIX}/lib"
++  CMAKE_PREFIX_PATH_USED="${PREFIX}:${CONDA_PREFIX}/@CHOST@/sysroot/usr"
+   CPATH_USED="${PREFIX}/include:${CONDA_PREFIX}"
+   LIBRARY_PATH_USED="${PREFIX}/compiler/lib:${LIBRARY_PATH}"
+   LD_LIBRARY_PATH_USED="${PREFIX}/compiler/lib/intel64_lin:${PREFIX}/compiler/lib:${PREFIX}/lib:${LD_LIBRARY_PATH}"
+ else
++  CFLAGS_USED="@CFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  DEBUG_CFLAGS_USED="@DEBUG_CFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  CPPFLAGS_USED="@CPPFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  DEBUG_CPPFLAGS_USED="@DEBUG_CPPFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  CXXFLAGS_USED="@CXXFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  DEBUG_CXXFLAGS_USED="@DEBUG_CXXFLAGS@ -isystem ${CONDA_PREFIX}/include"
++  LDFLAGS_USED="@LDFLAGS@ -Wl,-rpath,${CONDA_PREFIX}/lib -Wl,-rpath-link,${CONDA_PREFIX}/lib -L${CONDA_PREFIX}/lib"
++  LDFLAGS_LD_USED="@LDFLAGS_LD@ -rpath ${CONDA_PREFIX}/lib -rpath-link ${CONDA_PREFIX}/lib -L${CONDA_PREFIX}/lib"
++  CMAKE_PREFIX_PATH_USED="${CONDA_PREFIX}:${CONDA_PREFIX}/@CHOST@/sysroot/usr"
+   CPATH_USED="${CONDA_PREFIX}/include:${CONDA_PREFIX}"
+   LIBRARY_PATH_USED="${CONDA_PREFIX}/compiler/lib:${LIBRARY_PATH}"
+   LD_LIBRARY_PATH_USED="${CONDA_PREFIX}/compiler/lib/intel64_lin:${CONDA_PREFIX}/compiler/lib:${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"
+@@ -102,6 +123,24 @@ fi
+ 
+ _tc_activation \
+   deactivate @CHOST@- "HOST,@CHOST@" "BUILD,@CBUILD@" \
++  "CC,${CC:-@CHOST@-icx}" \
++  "CXX,${CXX:-@CHOST@-icpx}" \
++  "LD,${LD:-@CHOST@-ld.lld}" \
++  "AR,${AR:-@CHOST@-llvm-ar}" \
++  "RANLIB,${RANLIB:-@CHOST@-llvm-ranlib}" \
++  "CFLAGS,${CFLAGS:-${CFLAGS_USED}}" \
++  "DEBUG_CFLAGS,${DEBUG_CFLAGS:-${DEBUG_CFLAGS_USED}}" \
++  "CPPFLAGS,${CPPFLAGS:-${CPPFLAGS_USED}}" \
++  "DEBUG_CPPFLAGS,${DEBUG_CPPFLAGS:-${DEBUG_CPPFLAGS_USED}}" \
++  "CXXFLAGS,${CXXFLAGS:-${CXXFLAGS_USED}}" \
++  "DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-${DEBUG_CXXFLAGS_USED}}" \
++  "LDFLAGS,${LDFLAGS:-${LDFLAGS_USED}}" \
++  "LDFLAGS_LD,${LDFLAGS_LD:-${LDFLAGS_LD_USED}}" \
++  "CONDA_BUILD_SYSROOT,${CONDA_BUILD_SYSROOT_USED:-}" \
++  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME:-@_PYTHON_SYSCONFIGDATA_NAME@}" \
++  "CMAKE_ARGS,${_CMAKE_ARGS:-}" \
++  "CONDA_BUILD_CROSS_COMPILATION,@CONDA_BUILD_CROSS_COMPILATION@" \
++  "CMAKE_PREFIX_PATH,${CMAKE_PREFIX_PATH_USED}" \
+   "CPATH,${CPATH:-${CPATH_USED}}" \
+   "LIBRARY_PATH,${LIBRARY_PATH:-${LIBRARY_PATH_USED}}" \
+   "LD_LIBRARY_PATH,${LD_LIBRARY_PATH:-${LD_LIBRARY_PATH_USED}}"

--- a/recipe/patches/0001-dpcpp-activation.patch
+++ b/recipe/patches/0001-dpcpp-activation.patch
@@ -18,12 +18,12 @@ index c21165a..cbbc756 100755
 +  _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_FIND_ROOT_PATH=${PREFIX};${BUILD_PREFIX}/@CHOST@/sysroot"
 +  _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=lib"
 +
-+  CFLAGS_USED="@CFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
-+  DEBUG_CFLAGS_USED="@CFLAGS@ @DEBUG_CFLAGS@  --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  CFLAGS_USED="@CFLAGS@ --target=@CHOST@ --gcc-toolchain=${CONDA_PREFIX} --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  DEBUG_CFLAGS_USED="@CFLAGS@ @DEBUG_CFLAGS@  --target=@CHOST@ --gcc-toolchain=${CONDA_PREFIX} --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
 +  CPPFLAGS_USED="@CPPFLAGS@ -isystem ${PREFIX}/include"
 +  DEBUG_CPPFLAGS_USED="@DEBUG_CPPFLAGS@ -isystem ${PREFIX}/include"
-+  CXXFLAGS_USED="@CXXFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
-+  DEBUG_CXXFLAGS_USED="@CXXFLAGS@ @DEBUG_CXXFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  CXXFLAGS_USED="@CXXFLAGS@ --target=@CHOST@ --gcc-toolchain=${CONDA_PREFIX} --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  DEBUG_CXXFLAGS_USED="@CXXFLAGS@ @DEBUG_CXXFLAGS@ --target=@CHOST@ --gcc-toolchain=${CONDA_PREFIX} --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
 +  LDFLAGS_USED="@LDFLAGS@ --target=@CHOST@ -Wl,-rpath,${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib -Wl,-rpath,${BUILD_PREFIX}/lib -Wl,-rpath-link,${BUILD_PREFIX}/lib -L${BUILD_PREFIX}/lib"
 +  LDFLAGS_LD_USED="@LDFLAGS_LD@ --target=@CHOST@ -rpath ${PREFIX}/lib -rpath-link ${PREFIX}/lib -L${PREFIX}/lib -rpath ${BUILD_PREFIX}/lib -rpath-link ${BUILD_PREFIX}/lib -L${BUILD_PREFIX}/lib"
 +  CMAKE_PREFIX_PATH_USED="${PREFIX}:${CONDA_PREFIX}/@CHOST@/sysroot/usr"
@@ -86,12 +86,12 @@ index 6975b03..a4ff33f 100755
 +
  if [ "${CONDA_BUILD:-0}" = "1" ]; then
 +
-+  CFLAGS_USED="@CFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  CFLAGS_USED="@CFLAGS@ --target=@CHOST@ --gcc-toolchain=${CONDA_PREFIX} --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
 +  DEBUG_CFLAGS_USED="@CFLAGS@ @DEBUG_CFLAGS@  --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
 +  CPPFLAGS_USED="@CPPFLAGS@ -isystem ${PREFIX}/include"
 +  DEBUG_CPPFLAGS_USED="@DEBUG_CPPFLAGS@ -isystem ${PREFIX}/include"
-+  CXXFLAGS_USED="@CXXFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
-+  DEBUG_CXXFLAGS_USED="@CXXFLAGS@ @DEBUG_CXXFLAGS@ --target=@CHOST@ --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  CXXFLAGS_USED="@CXXFLAGS@ --target=@CHOST@ --gcc-toolchain=${CONDA_PREFIX} --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
++  DEBUG_CXXFLAGS_USED="@CXXFLAGS@ @DEBUG_CXXFLAGS@ --target=@CHOST@ --gcc-toolchain=${CONDA_PREFIX} --sysroot ${CONDA_BUILD_SYSROOT_USED} -isystem ${BUILD_PREFIX}/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
 +  LDFLAGS_USED="@LDFLAGS@ --target=@CHOST@ -Wl,-rpath,${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib -Wl,-rpath,${BUILD_PREFIX}/lib -Wl,-rpath-link,${BUILD_PREFIX}/lib -L${BUILD_PREFIX}/lib"
 +  LDFLAGS_LD_USED="@LDFLAGS_LD@ --target=@CHOST@ -rpath ${PREFIX}/lib -rpath-link ${PREFIX}/lib -L${PREFIX}/lib -rpath ${BUILD_PREFIX}/lib -rpath-link ${BUILD_PREFIX}/lib -L${BUILD_PREFIX}/lib"
 +  CMAKE_PREFIX_PATH_USED="${PREFIX}:${CONDA_PREFIX}/@CHOST@/sysroot/usr"

--- a/recipe/repack.sh
+++ b/recipe/repack.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -eux
 
 # for subpackages, we have named our extracted locations according to the subpackage name
 #    That's what this $PKG_NAME is doing - picking the right subfolder to rsync
@@ -7,6 +7,15 @@ set -ex
 src="${SRC_DIR}/${PKG_NAME}"
 
 cp -rv "${src}"/* "${PREFIX}/"
+
+# special case to set up compilers with host prepended.
+if [[ ${PKG_NAME} =~ dpcpp_impl_.* ]]; then
+    pushd "${PREFIX}"/bin
+        for file in *; do
+            ln -sfv ${file} ${CHOST}-${file}
+        done
+    popd
+fi
 
 # replace old info folder with our new regenerated one
 rm -rf "${PREFIX}/info"

--- a/recipe/simple.cpp
+++ b/recipe/simple.cpp
@@ -1,0 +1,44 @@
+#include <CL/sycl.hpp>
+#include <iostream>
+
+int main(void) {
+  std::cout << "SYCL_LANGUAGE_VERSION = "
+            << SYCL_LANGUAGE_VERSION
+            << std::endl;
+
+  sycl::queue q;
+  sycl::device d = q.get_device();
+
+  std::cout << "Device: "
+            << d.get_info<sycl::info::device::name>()
+            << std::endl;
+  std::cout << "Vendor: "
+            << d.get_info<sycl::info::device::vendor>()
+            << std::endl;
+  std::cout << "Driver: [" << d.get_platform().get_backend()
+            << "] Version: " << d.get_info<sycl::info::device::driver_version>()
+            << std::endl;
+
+  int v[16] = {2, 3, 5, 7,
+               11, 13, 17, 19,
+               23, 29, 31, 37,
+               41, 43, 47, 53};
+  int v2[16];
+  int *p_shared = sycl::malloc_shared<int>(16, q);
+  int *p_device = sycl::malloc_device<int>(16, q);
+  int *p_host = sycl::malloc_device<int>(16, q);
+
+  auto e1 = q.copy<int>(&v[0], p_shared, 16);
+  auto e2 = q.copy<int>(p_shared, p_device, 16, {e1});
+  auto e3 = q.copy<int>(p_device, p_host, 16, {e2});
+  auto e4 = q.copy<int>(p_host, &v2[0], 16, {e3});
+  e4.wait();
+
+  bool eq = std::equal(std::begin(v2), std::end(v2), std::begin(v));
+
+  sycl::free(p_shared, q);
+  sycl::free(p_device, q);
+  sycl::free(p_host, q);
+
+  return ((eq) ? 0 : 1);
+}

--- a/recipe/update-activate-and-repack.sh
+++ b/recipe/update-activate-and-repack.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+src="${SRC_DIR}/${PKG_NAME}"
+
+CBUILD=$(${PREFIX}/bin/icx -dumpmachine | sed "s/unknown/conda/")
+CHOST=$(${PREFIX}/bin/icx -dumpmachine | sed "s/unknown/conda/")
+
+FINAL_CFLAGS="-Wformat -Wformat-security -O3 -fp-model strict -fomit-frame-pointer -xSSE4.2 -axCORE-AVX2,COMMON-AVX512 -fPIC -fstack-protector-all -fno-plt -ftree-vectorize -ffunction-sections -pipe"
+FINAL_DEBUG_CFLAGS="-Wformat -Wformat-security -O0g -g -fp-model strict -fomit-frame-pointer -xSSE4.2 -axCORE-AVX2,COMMON-AVX512 -fPIC -fstack-protector-all -fno-plt -ftree-vectorize -ffunction-sections -pipe"
+FINAL_CPPFLAGS="-DNDEBUG -D_FORTIFY_SOURCE=2"
+FINAL_DEBUG_CPPFLAGS="-D_DEBUG -D_FORTIFY_SOURCE=2 -Og"
+FINAL_CXXFLAGS="-std=c++17 -Wformat -Wformat-security -O3 -fp-model strict -fomit-frame-pointer -xSSE4.2 -axCORE-AVX2,COMMON-AVX512 -fPIC -fstack-protector-all"
+FINAL_DEBUG_CXXFLAGS="-std=c++17 -Wformat -Wformat-security -O0g -g -fp-model strict -fomit-frame-pointer -xSSE4.2 -axCORE-AVX2,COMMON-AVX512 -fPIC -fstack-protector-all"
+FINAL_LDFLAGS="-Wl,-O3 -Wl,--sort-common -Wl,--as-needed -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--disable-new-dtags -Wl,--gc-sections -fuse-ld=lld"
+FINAL_LDFLAGS_LD="-O0g -g --sort-common --as-needed -z noexecstack -z relro -z now --disable-new-dtags --gc-sections -fuse-ld=lld"
+
+# if [[ "$target_platform" == "$ctng_target_platform" ]]; then
+#   export CONDA_BUILD_CROSS_COMPILATION=""
+# else
+#   export CONDA_BUILD_CROSS_COMPILATION="1"
+# fi
+# do not support cross compilation.
+export CONDA_BUILD_CROSS_COMPILATION=""
+
+pushd "${src}"
+
+find . -name "*activate*.sh" -exec sed -i.bak "s|@CBUILD@|${CBUILD}|g"                                                              "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@CHOST@|${CHOST}|g"                                                                "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@CFLAGS@|${FINAL_CFLAGS}|g"                                                       "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@DEBUG_CFLAGS@|${FINAL_DEBUG_CFLAGS}|g"                                           "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@CPPFLAGS@|${FINAL_CPPFLAGS}|g"                                                    "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@DEBUG_CPPFLAGS@|${FINAL_DEBUG_CPPFLAGS}|g"                                        "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@CXXFLAGS@|${FINAL_CXXFLAGS}|g"                                                   "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@DEBUG_CXXFLAGS@|${FINAL_DEBUG_CXXFLAGS}|g"                                       "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@LDFLAGS@|${FINAL_LDFLAGS}|g"                                                     "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@LDFLAGS_LD@|${FINAL_LDFLAGS_LD}|g"                                               "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@CONDA_BUILD_CROSS_COMPILATION@|${CONDA_BUILD_CROSS_COMPILATION}|g"                "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@_PYTHON_SYSCONFIGDATA_NAME@|${FINAL_PYTHON_SYSCONFIGDATA_NAME}|g"                 "{}" \;
+
+find . -name "*activate*.sh.bak" -exec rm "{}" \;
+
+popd
+
+# for subpackages, we have named our extracted locations according to the subpackage name
+#    That's what this $PKG_NAME is doing - picking the right subfolder to rsync
+
+cp -rv "${src}"/* "${PREFIX}/"
+
+# replace old info folder with our new regenerated one
+rm -rf "${PREFIX}/info"


### PR DESCRIPTION
Changes:
- Update version following PR 6
- Add compiler test, taken from cf
- Change selector to use linux instead of linux64 (as there are issues with linux64)
- Added activation scripts for linux.

Tests:
- Working on updating feedstock dpctl using this compiler. There are still issues there but at the moment it seems to be on dpctl side.

PS: the linter trips on this recipe.