### PR TITLE
Update to 2023.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -160,7 +160,7 @@ outputs:
         # OSX we use a slightly older version. This works perfectly fine but
         # we should get rid of it whenever we have a newer version.
         - intel-openmp {{ version.split('.')[0] }}.*              # [not osx]
-        - intel-openmp 2022.*,2023.*                              # [osx]
+        - intel-openmp                                            # [osx]
         - {{ pin_subpackage('intel-cmplr-lic-rt', exact=True) }}
         - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}  # [not osx]
     about:
@@ -195,7 +195,7 @@ outputs:
         # OSX we use a slightly older version. This works perfectly fine but
         # we should get rid of it whenever we have a newer version.
         - intel-openmp {{ version.split('.')[0] }}.*              # [not osx]
-        - intel-openmp 2022.*,2023.*                              # [osx]
+        - intel-openmp                                            # [osx]
         - {{ pin_subpackage('intel-cmplr-lic-rt', exact=True) }}
         - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}  # [not osx]
         - {{ pin_subpackage('intel-opencl-rt', exact=True) }}     # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -160,7 +160,7 @@ outputs:
         # OSX we use a slightly older version. This works perfectly fine but
         # we should get rid of it whenever we have a newer version.
         - intel-openmp {{ version.split('.')[0] }}.*              # [not osx]
-        - intel-openmp                                            # [osx]
+        - intel-openmp 2022.*,2023.*                              # [osx]
         - {{ pin_subpackage('intel-cmplr-lic-rt', exact=True) }}
         - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}  # [not osx]
     about:
@@ -195,7 +195,7 @@ outputs:
         # OSX we use a slightly older version. This works perfectly fine but
         # we should get rid of it whenever we have a newer version.
         - intel-openmp {{ version.split('.')[0] }}.*              # [not osx]
-        - intel-openmp                                            # [osx]
+        - intel-openmp 2022.*,2023.*                              # [osx]
         - {{ pin_subpackage('intel-cmplr-lic-rt', exact=True) }}
         - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}  # [not osx]
         - {{ pin_subpackage('intel-opencl-rt', exact=True) }}     # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -155,7 +155,12 @@ outputs:
         - "/opt/intel/compilers_and_libraries/linux/mpi/intel64/lib"
     requirements:
       run:
-        - intel-openmp {{ version.split('.')[0] }}.*
+        # Due to issues with Intel's repack of their oneAPI binaries for OSX,
+        # we could not update intel-openmp to the 2023 version. Therefore, for
+        # OSX we use a slightly older version. This works perfectly fine but
+        # we should get rid of it whenever we have a newer version.
+        - intel-openmp {{ version.split('.')[0] }}.*              # [not osx]
+        - intel-openmp                                            # [osx]
         - {{ pin_subpackage('intel-cmplr-lic-rt', exact=True) }}
         - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}  # [not osx]
     about:
@@ -185,7 +190,12 @@ outputs:
         - '*'
     requirements:
       run:
-        - intel-openmp {{ version.split('.')[0] }}.*
+        # Due to issues with Intel's repack of their oneAPI binaries for OSX,
+        # we could not update intel-openmp to the 2023 version. Therefore, for
+        # OSX we use a slightly older version. This works perfectly fine but
+        # we should get rid of it whenever we have a newer version.
+        - intel-openmp {{ version.split('.')[0] }}.*              # [not osx]
+        - intel-openmp                                            # [osx]
         - {{ pin_subpackage('intel-cmplr-lic-rt', exact=True) }}
         - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}  # [not osx]
         - {{ pin_subpackage('intel-opencl-rt', exact=True) }}     # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,16 @@
-{% set version = "2022.1.0" %}          # [linux]
-{% set version = "2022.1.0" %}          # [osx or win]
-{% set intel_build_number = "3768" %}   # [linux]
-{% set intel_build_number = "3718" %}   # [osx]
-{% set intel_build_number = "3787" %}   # [win]
+{% set version = "2023.0.0" %}           # [linux]
+{% set version = "2023.0.0" %}           # [osx or win]
+{% set intel_build_number = "25370" %}   # [linux]
+{% set intel_build_number = "25369" %}   # [osx]
+{% set intel_build_number = "25922" %}   # [win]
 
-{% set oneccl_version = "2021.5.0" %}
-{% set oneccl_build_number = "478" %}
+{% set oneccl_version = "2021.8.0" %}
+{% set oneccl_build_number = "25371" %}
 
 {% set tbb_version = "2021.6.0" %}
 
-{% set mkl_dpcpp_build_number = "223" %}  # [linux]
-{% set mkl_dpcpp_build_number = "192" %}  # [win]
+{% set mkl_dpcpp_build_number = "25398" %}  # [linux]
+{% set mkl_dpcpp_build_number = "25930" %}  # [win]
 
 # use this if our build script changes and we need to increment beyond intel's version
 {% set dst_build_number = '0' %}
@@ -299,8 +299,7 @@ outputs:
         - dir %PREFIX%\Library\bin\*  # [win]
         - dir %PREFIX%\Library\lib\*  # [win]
         - icpx --dpcpp -fsycl --gcc-toolchain=$PREFIX --sysroot=$PREFIX/$HOST/sysroot -target $HOST ${LDFLAGS} ${CXXFLAGS} simple.cpp -lpthread -o simple  # [unix]
-        # Need for -I option is a bug in compiler activation script. Can be removed when fixed
-        - dpcpp simple.cpp -I%PREFIX%\include -o simple.exe  # [win]
+        - icpx -fsycl simple.cpp -o simple.exe # [win]
 
   - name: oneccl-devel
     version: {{ oneccl_version }}

--- a/recipe/repack.sh
+++ b/recipe/repack.sh
@@ -6,7 +6,7 @@ set -eux
 
 src="${SRC_DIR}/${PKG_NAME}"
 
-cp -rv "${src}"/* "${PREFIX}/"
+cp -av "${src}"/* "${PREFIX}/"
 
 # special case to set up compilers with host prepended.
 if [[ ${PKG_NAME} =~ dpcpp_impl_.* ]]; then


### PR DESCRIPTION
A rather simple change to upgrade our Intel compilers collection. Nothing major, except that for `osx-64` we need to use an older `intel-openmp` because Paul's latest change did not build it for this platform (that's a different story...).