### PR TITLE
Rebuild against libxml2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,3 +4,5 @@ FINAL_PYTHON_SYSCONFIGDATA_NAME:                    # [linux]
   - _sysconfigdata_x86_64_conda_linux_gnu           # [linux]
 binutils_version:       # [linux]
   - 2.30                # [linux]
+libxml2:
+  - 2.14.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@
 {% set intel_ch = "https://software.repos.intel.com/python/conda" %}
 
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dst_build_number = '0' %}
+{% set dst_build_number = '1' %}
 {% set build_number = intel_build_number|int + dst_build_number|int %}
 
 package:
@@ -283,7 +283,7 @@ outputs:
         - khronos-opencl-icd-loader  # [win]
         # TODO: do we need zlib and libxml2 here?
         - zlib
-        - libxml2
+        - libxml2 2.14.4
         - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}
       run:
         - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -283,7 +283,7 @@ outputs:
         - khronos-opencl-icd-loader  # [win]
         # TODO: do we need zlib and libxml2 here?
         - zlib
-        - libxml2 2.14.4
+        - libxml2 {{ libxml2 }}
         - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}
       run:
         - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}


### PR DESCRIPTION
intel-compilers-repack 2025.0.4

**Destination channel:** defaults

### Links

- [PKG-12522](https://anaconda.atlassian.net/browse/PKG-12522) 
- [Upstream repository](https://software.repos.intel.com/python/conda)

### Explanation of changes:
- Update libxml2 in dependency


[PKG-12522]: https://anaconda.atlassian.net/browse/PKG-12522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ