### PR TITLE
Rebuild against libxml2 2.15.3

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,4 +5,4 @@ FINAL_PYTHON_SYSCONFIGDATA_NAME:                    # [linux]
 binutils_version:       # [linux]
   - 2.30                # [linux]
 libxml2:
-  - 2.14.4
+  - 2.15.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@
 {% set intel_ch = "https://software.repos.intel.com/python/conda" %}
 
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dst_build_number = '1' %}
+{% set dst_build_number = '2' %}
 {% set build_number = intel_build_number|int + dst_build_number|int %}
 
 package:
@@ -96,6 +96,7 @@ outputs:
       # linking only for the packages that are presented in build and host and
       # have run_export section.
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
       host:
@@ -140,6 +141,7 @@ outputs:
       # linking only for the packages that are presented in build and host and
       # have run_export section.
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
       host:
@@ -192,6 +194,7 @@ outputs:
         - {{ pin_subpackage("intel-sycl-rt", max_pin="x") }}
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
       host:
@@ -229,6 +232,7 @@ outputs:
         - {{ pin_subpackage("intel-fortran-rt", max_pin="x") }}
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - patchelf                 # [linux]
       host:
@@ -269,6 +273,7 @@ outputs:
         - {{ pin_subpackage("intel-opencl-rt", max_pin="x") }}
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - patchelf               # [linux]
         - python *  # [win]
@@ -323,6 +328,7 @@ outputs:
       number: {{ umf_build_number|int + dst_build_number|int }}
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
       host:
         # intel-cmplr-lic-rt is a license file, please do not remove.


### PR DESCRIPTION
intel-compiler-repack 2025.0.4

**Destination channel:**  defaults

### Links

- [PKG-15896](https://anaconda.atlassian.net/browse/PKG-15896) 
- [Upstream repository](https://github.com/AnacondaRecipes/intel-compilers-repack-feedstock)

### Explanation of changes:
- New version of libxml2
- Adding stdlib to build section

[PKG-15896]: https://anaconda.atlassian.net/browse/PKG-15896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ